### PR TITLE
Fix Swagger JSON building

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -79,7 +79,7 @@ def generate_doc_from_each_end_point(app: web.Application,
             else:
                 url = url_info.get("formatter")
     
-            swagger["paths"][url] = end_point_doc
+            swagger["paths"][url].update(end_point_doc)
     
     return json.dumps(swagger)
 


### PR DESCRIPTION
Addresses: #12

The problems is in overwriting URL handlers, it was required to do dict `update` rather than reassignment.