### PR TITLE
Support python 3.4 and python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ aiohttp-swagger
 Code | https://github.com/cr0hn/aiohttp-swagger
 ---- | ----------------------------------------------
 Issues | https://github.com/cr0hn/aiohttp-swagger/issues/
-Python version | Python 3.5 and above
+Python version | Python 3.4 and above
 
 What's aiohttp-swagger
 ----------------------
 
-aiohttp-swagger is a plugin for aiohttp.web server that allow to document APIs using Swagger show the Swagger-ui console. 
+aiohttp-swagger is a plugin for aiohttp.web server that allow to document APIs using Swagger show the Swagger-ui console.
 
 Installation
 ------------
@@ -36,7 +36,7 @@ To install the tool with extra performance you must do:
 $ python3.5 -m pip install 'aiohttp-swagger[performance]'
 ```
 
-**Remember that aiohttp-swagger only runs in Python 3.5 and above**.
+**Remember that aiohttp-swagger only runs in Python 3.4 and above**.
 
 Quick start
 -----------
@@ -272,7 +272,7 @@ async def ping(request):
 
     >>> import json
     >>> ping(None)
-    
+
     :param request: Context injected by aiohttp framework
     :type request: RequestHandler
     """
@@ -301,13 +301,13 @@ F.A.Q.
 async def ping(request):
     """
     This is my usually Sphinx doc
-    
+
     >>> import json
     >>> ping(None)
-    
-    :param request: Context injected by aiohttp framework  
-    :type request: RequestHandler 
-    
+
+    :param request: Context injected by aiohttp framework
+    :type request: RequestHandler
+
     ---
     description: This end-point allow to test that service is up.
     tags:
@@ -329,7 +329,7 @@ async def ping(request):
 
 - Q: How can I change the Title of a group of End-Points?
 - A: Swagger has a tag that uses to build the titles. The tag name is **tags**. The format is:
- 
+
 ```yaml
 tags:  # <-- TAG USEF FOR THE TITLE
 - Health check
@@ -352,7 +352,7 @@ Swagger Documentation & Examples
 You can read the Swagger parameters and format at:
 
 [OpenAPI Spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)
-    
+
 If you need more examples, there're some available in at folder: [aiohttp_swagger/examples](https://github.com/cr0hn/aiohttp-swagger/tree/master/examples).
 
 What's new?

--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 from os.path import join, dirname, abspath
 
 from aiohttp import web
@@ -5,14 +6,16 @@ from aiohttp import web
 from .helpers import swagger_path, generate_doc_from_each_end_point, load_doc_from_yaml_file
 
 
-async def _swagger_home(request):
+@asyncio.coroutine
+def _swagger_home(request):
     """
     Return the index.html main file
     """
     return web.Response(text=request.app["SWAGGER_TEMPLATE_CONTENT"], content_type="text/html")
 
 
-async def _swagger_def(request):
+@asyncio.coroutine
+def _swagger_def(request):
     """
     Returns the Swagger JSON Definition
     """
@@ -33,7 +36,7 @@ def setup_swagger(app: web.Application,
                   contact: str = ""):
     _swagger_url = "/{}".format(swagger_url) if not swagger_url.startswith("/") else swagger_url
     _swagger_def_url = '{}/swagger.json'.format(_swagger_url)
-    
+
     # Build Swagget Info
     if swagger_from_file:
         swagger_info = load_doc_from_yaml_file(swagger_from_file)
@@ -44,16 +47,16 @@ def setup_swagger(app: web.Application,
                                                         api_version=api_version,
                                                         title=title,
                                                         contact=contact)
-    
+
     # Add API routes
     app.router.add_route('GET', _swagger_url, _swagger_home)
     app.router.add_route('GET', "{}/".format(_swagger_url), _swagger_home)
     app.router.add_route('GET', _swagger_def_url, _swagger_def)
-    
+
     # Set statics
     statics_path = '{}/swagger_static'.format(_swagger_url)
     app.router.add_static(statics_path, STATIC_PATH)
-    
+
     # --------------------------------------------------------------------------
     # Build templates
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Add support for Python 3.4.

I think you should support it as long as major distributions still use Python 3.4 as their standard Python 3 version. This is for example the case for Debian Jessie.

:beers: 