### PR TITLE
Fixing broken link on the top logo

### DIFF
--- a/aiohttp_swagger/swagger_ui/index.html
+++ b/aiohttp_swagger/swagger_ui/index.html
@@ -91,7 +91,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="##STATIC_PATH##/http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="##STATIC_PATH##/images/logo_small.png" /><span class="logo__title">swagger</span></a>
+    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="##STATIC_PATH##/images/logo_small.png" /><span class="logo__title">swagger</span></a>
     <form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       <div id='auth_container'></div>


### PR DESCRIPTION
##STATIC_PATH## is only for images, not for the link to external webpage