### PR TITLE
[WIP] Prepare aiohttp-swagger to aio-libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install:
+  - python setup.py install
+  - pip install -r requirements-dev.txt
+  - pip install codecov
+
+script:
+  - make cov
+
+after_success:
+  - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Some simple testing tasks (sorry, UNIX only).
+
+cov:
+	@py.test --cov=aiohttp_swagger --cov-report=term --cov-report=html tests
+
+clean:
+	@rm -rf `find . -name __pycache__`
+	@rm -f `find . -type f -name '*.py[co]' `
+	@rm -f `find . -type f -name '*~' `
+	@rm -f `find . -type f -name '.*~' `
+	@rm -f `find . -type f -name '@*' `
+	@rm -f `find . -type f -name '#*#' `
+	@rm -f `find . -type f -name '*.orig' `
+	@rm -f `find . -type f -name '*.rej' `
+	@rm -f .coverage
+	@rm -rf coverage
+	@rm -rf build
+	@rm -rf cover
+	@make -C docs clean
+	@python setup.py clean
+	@rm -rf .tox
+
+install:
+	@pip install -U pip
+	@pip install -Ur requirements-dev.txt

--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -1,9 +1,10 @@
 import asyncio
-from os.path import join, dirname, abspath
+from os.path import abspath, dirname, join
 
 from aiohttp import web
 
-from .helpers import swagger_path, generate_doc_from_each_end_point, load_doc_from_yaml_file
+from .helpers import (generate_doc_from_each_end_point,
+                      load_doc_from_yaml_file, swagger_path)
 
 
 @asyncio.coroutine
@@ -11,7 +12,10 @@ def _swagger_home(request):
     """
     Return the index.html main file
     """
-    return web.Response(text=request.app["SWAGGER_TEMPLATE_CONTENT"], content_type="text/html")
+    return web.Response(
+        text=request.app["SWAGGER_TEMPLATE_CONTENT"],
+        content_type="text/html"
+    )
 
 
 @asyncio.coroutine
@@ -34,19 +38,19 @@ def setup_swagger(app: web.Application,
                   api_version: str = "1.0.0",
                   title: str = "Swagger API",
                   contact: str = ""):
-    _swagger_url = "/{}".format(swagger_url) if not swagger_url.startswith("/") else swagger_url
+    _swagger_url = ("/{}".format(swagger_url)
+                    if not swagger_url.startswith("/")
+                    else swagger_url)
     _swagger_def_url = '{}/swagger.json'.format(_swagger_url)
 
     # Build Swagget Info
     if swagger_from_file:
         swagger_info = load_doc_from_yaml_file(swagger_from_file)
     else:
-        swagger_info = generate_doc_from_each_end_point(app,
-                                                        api_base_url=api_base_url,
-                                                        description=description,
-                                                        api_version=api_version,
-                                                        title=title,
-                                                        contact=contact)
+        swagger_info = generate_doc_from_each_end_point(
+            app, api_base_url=api_base_url, description=description,
+            api_version=api_version, title=title, contact=contact
+        )
 
     # Add API routes
     app.router.add_route('GET', _swagger_url, _swagger_home)
@@ -61,9 +65,11 @@ def setup_swagger(app: web.Application,
     # Build templates
     # --------------------------------------------------------------------------
     app["SWAGGER_DEF_CONTENT"] = swagger_info
-    app["SWAGGER_TEMPLATE_CONTENT"] = open(join(STATIC_PATH, "index.html"), "r").read() \
-        .replace("##SWAGGER_CONFIG##", _swagger_def_url) \
+    app["SWAGGER_TEMPLATE_CONTENT"] = (
+        open(join(STATIC_PATH, "index.html"), "r").read()
+        .replace("##SWAGGER_CONFIG##", _swagger_def_url)
         .replace("##STATIC_PATH##", statics_path)
+    )
 
 
 __all__ = ("setup_swagger", "swagger_path")

--- a/aiohttp_swagger/helpers/__init__.py
+++ b/aiohttp_swagger/helpers/__init__.py
@@ -1,2 +1,2 @@
-from .builders import *
-from .decorators import *
+from .builders import *  # noqa
+from .decorators import *  # noqa

--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -1,15 +1,15 @@
+from collections import defaultdict
+from os.path import abspath, dirname, join
+
 import yaml
+from aiohttp import web
+from jinja2 import Template
 
 try:
     import ujson as json
 except ImportError:
     import json
 
-from collections import defaultdict
-from os.path import join, dirname, abspath
-
-from aiohttp import web
-from jinja2 import Template
 
 SWAGGER_TEMPLATE = abspath(join(dirname(__file__), "..", "templates"))
 
@@ -26,10 +26,13 @@ def _build_doc_from_func_doc(route):
 
     # Build JSON YAML Obj
     try:
-        end_point_swagger_doc = yaml.load("\n".join(end_point_doc[end_point_swagger_start:]))
+        end_point_swagger_doc = (
+            yaml.load("\n".join(end_point_doc[end_point_swagger_start:]))
+        )
     except yaml.YAMLError:
         end_point_swagger_doc = {
-            "description": "⚠ Swagger document could not be loaded from docstring ⚠",
+            "description": "⚠ Swagger document could not be loaded "
+                           "from docstring ⚠",
             "tags": ["Invalid Swagger"]
         }
 
@@ -37,13 +40,14 @@ def _build_doc_from_func_doc(route):
     return {route.method.lower(): end_point_swagger_doc}
 
 
-def generate_doc_from_each_end_point(app: web.Application,
-                                     *,
-                                     api_base_url: str = "/",
-                                     description: str = "Swagger API definition",
-                                     api_version: str = "1.0.0",
-                                     title: str = "Swagger API",
-                                     contact: str = ""):
+def generate_doc_from_each_end_point(
+        app: web.Application,
+        *,
+        api_base_url: str = "/",
+        description: str = "Swagger API definition",
+        api_version: str = "1.0.0",
+        title: str = "Swagger API",
+        contact: str = ""):
     # Clean description
     _start_desc = 0
     for i, word in enumerate(description):
@@ -53,12 +57,13 @@ def generate_doc_from_each_end_point(app: web.Application,
     cleaned_description = "    ".join(description[_start_desc:].splitlines())
 
     # Load base Swagger template
-    swagger_base = Template(open(join(SWAGGER_TEMPLATE, "swagger.yaml"), "r").read()).render(
-        description=cleaned_description,
-        version=api_version,
-        title=title,
-        contact=contact,
-        base_path=api_base_url
+    swagger_base = (
+        Template(open(join(SWAGGER_TEMPLATE, "swagger.yaml"), "r").read()).render(
+            description=cleaned_description,
+            version=api_version,
+            title=title,
+            contact=contact,
+            base_path=api_base_url)
     )
 
     # The Swagger OBJ
@@ -73,25 +78,30 @@ def generate_doc_from_each_end_point(app: web.Application,
         if getattr(route.handler, "swagger_file", False):
             try:
                 end_point_doc = {
-                    route.method.lower(): yaml.load(open(route.handler.swagger_file, "r").read())
+                    route.method.lower():
+                        yaml.load(open(route.handler.swagger_file, "r").read())
                 }
             except yaml.YAMLError:
                 end_point_doc = {
                     route.method.lower(): {
-                        "description": "⚠ Swagger document could not be loaded from file ⚠",
+                        "description": "⚠ Swagger document could not be "
+                                       "loaded from file ⚠",
                         "tags": ["Invalid Swagger"]
                     }
                 }
             except FileNotFoundError:
                 end_point_doc = {
                     route.method.lower(): {
-                        "description": "⚠ Swagger file not found ({}) ⚠".format(route.handler.swagger_file),
+                        "description":
+                            "⚠ Swagger file not "
+                            "found ({}) ⚠".format(route.handler.swagger_file),
                         "tags": ["Invalid Swagger"]
                     }
                 }
 
         # Check if end-point has Swagger doc
-        elif route.handler.__doc__ is not None and "---" in route.handler.__doc__:
+        elif (route.handler.__doc__ is not None
+              and "---" in route.handler.__doc__):
             end_point_doc = _build_doc_from_func_doc(route)
 
         # there is doc available?

--- a/aiohttp_swagger/helpers/decorators.py
+++ b/aiohttp_swagger/helpers/decorators.py
@@ -5,4 +5,3 @@ class swagger_path(object):
     def __call__(self, f):
         f.swagger_file = self.swagger_file
         return f
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest
+pytest-cov
+pytest-aiohttp
+flake8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
-pytest
-pytest-aiohttp

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,31 @@
 #
 # aiohttp-swagger
 #
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-# following conditions are met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
 #
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
-# following disclaimer.
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
 #
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-# following disclaimer in the documentation and/or other materials provided with the distribution.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
 #
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-# products derived from this software without specific prior written permission.
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 #
 
 from os.path import dirname, join
@@ -72,9 +78,9 @@ setup(
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Security',
     ],
     tests_require=['pytest', 'pytest-aiohttp'],
     cmdclass=dict(test=PyTest)
 )
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py34, py35, py36
+
+[testenv]
+deps = -rrequirements-dev.txt
+commands = py.test


### PR DESCRIPTION
TODO:
- [ ] Public API should be described explicitly like http://aiohttp.readthedocs.io/en/stable/web_reference.html (I strongly suggest to don't use autodoc because narrative documentation is much better for reading)
- [ ] The project's test suite should be checked by travis ci
- [ ] tests should be covered by pytest-cov plugin. Right now I see 82% (not bad but several tests could make it up to 100%)
- [x] Strict flake8 checks (yes, 79 chars per line is important requirement for me)
cc @asvetlov @cr0hn 
