### PR TITLE
Add support for aiohttp Nested Applications

### DIFF
--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -91,8 +91,10 @@ def setup_swagger(app: web.Application,
     with open(join(STATIC_PATH, "index.html"), "r") as f:
         app["SWAGGER_TEMPLATE_CONTENT"] = (
             f.read()
-            .replace("##SWAGGER_CONFIG##", _swagger_def_url)
-            .replace("##STATIC_PATH##", statics_path)
+            .replace("##SWAGGER_CONFIG##", '/{}{}'.
+                     format(api_base_url.lstrip('/'), _swagger_def_url))
+            .replace("##STATIC_PATH##", '/{}{}'.
+                     format(api_base_url.lstrip('/'), statics_path))
         )
 
 

--- a/doc/source/customizing.rst
+++ b/doc/source/customizing.rst
@@ -167,3 +167,32 @@ Global Swagger YAML
     setup_swagger(app, swagger_from_file="example_swagger.yaml")  # <-- Loaded Swagger from external YAML file
 
     web.run_app(app, host="127.0.0.1")
+
+Nested applications
++++++++++++++++++++
+
+:samp:`aiohttp-swagger` is compatible with aiohttp `Nested applications <http://aiohttp.readthedocs.io/en/stable/web.html>`_ feature.
+In this case `api_base_url` argument of `setup_swagger` function should be the same as `prefix` argument of `add_subapp` method:
+
+
+.. code-block:: python
+
+    from aiohttp import web
+    from aiohttp_swagger import *
+
+    async def ping(request):
+        return web.Response(text="pong")
+
+    sub_app = web.Application()
+
+    sub_app.router.add_route('GET', "/ping", ping)
+
+    setup_swagger(sub_app,
+                  swagger_from_file="example_swagger.yaml",
+                  api_base_url='/sub_app_prefix')
+
+    app = web.Application()
+
+    app.add_subapp(prefix='/sub_app_prefix', subapp=sub_app)
+
+    web.run_app(app, host="127.0.0.1")


### PR DESCRIPTION
Add support for aiohttp [Nested Applications](http://aiohttp.readthedocs.io/en/stable/web.html?highlight=Nested%20applications) by using existed argument **api_base_url** as sub application prefix. Added corresponding test and documentation update