### PR TITLE
Add support for securityDefinitions (Closes #39)

### DIFF
--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -46,7 +46,8 @@ def setup_swagger(app: web.Application,
                   contact: str = "",
                   swagger_home_decor: FunctionType = None,
                   swagger_def_decor: FunctionType = None,
-                  swagger_info: dict = None):
+                  swagger_info: dict = None,
+                  security_definitions: dict = None):
     _swagger_url = ("/{}".format(swagger_url)
                     if not swagger_url.startswith("/")
                     else swagger_url)
@@ -60,7 +61,8 @@ def setup_swagger(app: web.Application,
         else:
             swagger_info = generate_doc_from_each_end_point(
                 app, api_base_url=api_base_url, description=description,
-                api_version=api_version, title=title, contact=contact
+                api_version=api_version, title=title, contact=contact,
+                security_definitions=security_definitions,
             )
     else:
         swagger_info = json.dumps(swagger_info)

--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 import yaml
 from aiohttp import web
 from aiohttp.hdrs import METH_ANY, METH_ALL
-from jinja2 import Template
+from jinja2 import Environment, BaseLoader
 
 try:
     import ujson as json
@@ -66,7 +66,8 @@ def generate_doc_from_each_end_point(
         description: str = "Swagger API definition",
         api_version: str = "1.0.0",
         title: str = "Swagger API",
-        contact: str = ""):
+        contact: str = "",
+        security_definitions: dict = None):
     # Clean description
     _start_desc = 0
     for i, word in enumerate(description):
@@ -75,15 +76,28 @@ def generate_doc_from_each_end_point(
             break
     cleaned_description = "    ".join(description[_start_desc:].splitlines())
 
+    def nesteddict2yaml(d, indent=10, result=""):
+        for key, value in d.items():
+            result += " " * indent + str(key) + ':'
+            if isinstance(value, dict):
+                result = nesteddict2yaml(value, indent + 2, result + "\n")
+            else:
+                result += " " + str(value) + "\n"
+        return result
+
     # Load base Swagger template
+    jinja2_env = Environment(loader=BaseLoader())
+    jinja2_env.filters['nesteddict2yaml'] = nesteddict2yaml
+
     with open(join(SWAGGER_TEMPLATE, "swagger.yaml"), "r") as f:
         swagger_base = (
-            Template(f.read()).render(
+            jinja2_env.from_string(f.read()).render(
                 description=cleaned_description,
                 version=api_version,
                 title=title,
                 contact=contact,
-                base_path=api_base_url)
+                base_path=api_base_url,
+                security_definitions=security_definitions)
         )
 
     # The Swagger OBJ

--- a/aiohttp_swagger/templates/swagger.yaml
+++ b/aiohttp_swagger/templates/swagger.yaml
@@ -12,4 +12,8 @@ basePath: {{ base_path }}
 schemes:
   - http
   - https
+{% if security_definitions %}
+securityDefinitions:
+{{ security_definitions|nesteddict2yaml }}
+{% endif %}
 paths:

--- a/examples/example_05.py
+++ b/examples/example_05.py
@@ -35,6 +35,22 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula, met
                   description=long_description,
                   title="My Custom Title",
                   api_version="1.0.3",
-                  contact="my.custom.contact@example.com")
+                  contact="my.custom.contact@example.com",
+                  security_definitions={
+                      'basicAuth': {
+                          'type': 'basic',
+                      },
+                      'OAuth2': {
+                          'type': 'oauth2',
+                          'flow': 'accessCode',
+                          'authorizationUrl': 'https://example.com/oauth/authorize',
+                          'tokenUrl': 'https://example.com/oauth/token',
+                          'scopes': {
+                              'read': 'Grants read access',
+                              'write': 'Grants write access',
+                              'admin': 'Grants read and write access to administrative information',
+                          }
+                      }
+                  })
     
     web.run_app(app, host="127.0.0.1")


### PR DESCRIPTION
Hello,

securityDefinitions can now be passed to setup_swagger, here is out it looks from ui perspective:
An example has been added to example_05.py.

![aiohttp_swagger_ui_security](https://user-images.githubusercontent.com/1586757/47566685-be579780-d92c-11e8-8fae-376bc2327430.jpg)

Thanks, Adam.