### PR TITLE
PyYAML yaml.load(input) Deprecation

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -152,7 +152,7 @@ def generate_doc_from_each_end_point(
 
 
 def load_doc_from_yaml_file(doc_path: str):
-    loaded_yaml = yaml.load(open(doc_path, "r").read())
+    loaded_yaml = yaml.load(open(doc_path, "r").read(), Loader=yaml.FullLoader)
     return json.dumps(loaded_yaml)
 
 

--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -26,7 +26,7 @@ def _extract_swagger_docs(end_point_doc, method="get"):
     # Build JSON YAML Obj
     try:
         end_point_swagger_doc = (
-            yaml.load("\n".join(end_point_doc[end_point_swagger_start:]))
+            yaml.load("\n".join(end_point_doc[end_point_swagger_start:]), Loader=yaml.FullLoader)
         )
     except yaml.YAMLError:
         end_point_swagger_doc = {
@@ -101,7 +101,7 @@ def generate_doc_from_each_end_point(
         )
 
     # The Swagger OBJ
-    swagger = yaml.load(swagger_base)
+    swagger = yaml.load(swagger_base, Loader=yaml.FullLoader)
     swagger["paths"] = defaultdict(dict)
 
     for route in app.router.routes():
@@ -114,7 +114,7 @@ def generate_doc_from_each_end_point(
                 with open(route.handler.swagger_file, "r") as f:
                     end_point_doc = {
                         route.method.lower():
-                            yaml.load(f.read())
+                            yaml.load(f.read(), Loader=yaml.FullLoader)
                     }
             except yaml.YAMLError:
                 end_point_doc = {


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Default loader is not safe anymore. I decided to remove highlight warnings in terminal.