### PR TITLE
#60 fix pyaml load file

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -26,7 +26,7 @@ def _extract_swagger_docs(end_point_doc, method="get"):
     # Build JSON YAML Obj
     try:
         end_point_swagger_doc = (
-            yaml.load("\n".join(end_point_doc[end_point_swagger_start:]))
+            yaml.full_load("\n".join(end_point_doc[end_point_swagger_start:]))
         )
     except yaml.YAMLError:
         end_point_swagger_doc = {
@@ -101,7 +101,7 @@ def generate_doc_from_each_end_point(
         )
 
     # The Swagger OBJ
-    swagger = yaml.load(swagger_base)
+    swagger = yaml.full_load(swagger_base)
     swagger["paths"] = defaultdict(dict)
 
     for route in app.router.routes():
@@ -114,7 +114,7 @@ def generate_doc_from_each_end_point(
                 with open(route.handler.swagger_file, "r") as f:
                     end_point_doc = {
                         route.method.lower():
-                            yaml.load(f.read())
+                            yaml.full_load(f.read())
                     }
             except yaml.YAMLError:
                 end_point_doc = {
@@ -152,7 +152,7 @@ def generate_doc_from_each_end_point(
 
 
 def load_doc_from_yaml_file(doc_path: str):
-    loaded_yaml = yaml.load(open(doc_path, "r").read())
+    loaded_yaml = yaml.full_load(open(doc_path, "r").read())
     return json.dumps(loaded_yaml)
 
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -195,7 +195,7 @@ def test_swagger_def_decorator(test_client, loop):
 @pytest.fixture
 def swagger_info():
     filename = abspath(join(dirname(__file__))) + "/data/example_swagger.yaml"
-    return yaml.load(open(filename).read())
+    return yaml.full_load(open(filename).read())
 
 
 @asyncio.coroutine


### PR DESCRIPTION
use yaml.full_load

Address following warning:
    YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated

Please read https://msg.pyyaml.org/load for full details.

Fixes #60 

Signed-off-by: Alexandr Sukhrin <alexandrvirtual@gmail.com>