### PR TITLE
remove python 3.4 in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 


### PR DESCRIPTION
An error occurs when building and testing a project.
Because aiohttp 3.x requires Python 3.5.3+