### PR TITLE
Fix path to static files

### DIFF
--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -93,10 +93,10 @@ def setup_swagger(app: web.Application,
     with open(join(STATIC_PATH, "index.html"), "r") as f:
         app["SWAGGER_TEMPLATE_CONTENT"] = (
             f.read()
-            .replace("##SWAGGER_CONFIG##", '/{}{}'.
-                     format(api_base_url.lstrip('/'), _swagger_def_url))
-            .replace("##STATIC_PATH##", '/{}{}'.
-                     format(api_base_url.lstrip('/'), statics_path))
+            .replace("##SWAGGER_CONFIG##", '{}{}'.
+                     format(api_base_url.rstrip('/'), _swagger_def_url))
+            .replace("##STATIC_PATH##", '{}{}'.
+                     format(api_base_url.rstrip('/'), statics_path))
         )
 
 


### PR DESCRIPTION
Even with default values of `api_base_url` and `swagger_url` it produced path `//api/doc` which is wrong. Nobody else hit this issue?