### PR TITLE
Fix an issue with wrong methods in generated UI. Issue #68

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -57,7 +57,7 @@ def _build_doc_from_func_doc(route):
             end_point_doc = route.handler.__doc__.splitlines()
         except AttributeError:
             return {}
-        out.update(_extract_swagger_docs(end_point_doc))
+        out.update(_extract_swagger_docs(end_point_doc, method=str(route.method).lower()))
     return out
 
 def generate_doc_from_each_end_point(

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -231,6 +231,24 @@ def test_undocumented_fn(test_client, loop):
     result = json.loads(text)
     assert not result['paths']
 
+
+@asyncio.coroutine
+def test_wrong_method(test_client, loop):
+    app = web.Application(loop=loop)
+    app.router.add_route('POST', "/post_ping", ping)
+    setup_swagger(app)
+    client = yield from test_client(app)
+    # GET
+    swagger_resp1 = yield from client.get('/api/doc/swagger.json')
+    assert swagger_resp1.status == 200
+    text = yield from swagger_resp1.text()
+    result = json.loads(text)
+    assert "/post_ping" in result['paths']
+    assert "post" in result['paths']["/post_ping"]
+    resp = yield from client.get('/post_ping')
+    assert resp.status == 405
+
+
 @asyncio.coroutine
 def test_class_view(test_client, loop):
     app = web.Application(loop=loop)


### PR DESCRIPTION
Swagger UI generates wrong methods in the documentation. All methods will be "GET".

How to reproduce:
```
from aiohttp import web
from aiohttp_swagger import setup_swagger
routes = web.RouteTableDef()
@routes.post('/ping')
async def ping(request):
    """
    ---
    description: This end-point allow to test that service is up.
    tags:
    - Health check
    produces:
    - text/plain
    responses:
        "200":
            description: successful operation. Return "pong" text
        "405":
            description: invalid HTTP Method
    """
    return web.Response(text="pong")
app = web.Application()
app.add_routes(routes)
setup_swagger(app)
web.run_app(app, host="127.0.0.1")
```