### PR TITLE
Add possibility to provide data definitions

### DIFF
--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -47,6 +47,7 @@ def setup_swagger(app: web.Application,
                   swagger_home_decor: FunctionType = None,
                   swagger_def_decor: FunctionType = None,
                   swagger_info: dict = None,
+                  definitions: dict = None,
                   security_definitions: dict = None):
     _swagger_url = ("/{}".format(swagger_url)
                     if not swagger_url.startswith("/")
@@ -62,6 +63,7 @@ def setup_swagger(app: web.Application,
             swagger_info = generate_doc_from_each_end_point(
                 app, api_base_url=api_base_url, description=description,
                 api_version=api_version, title=title, contact=contact,
+                definitions=definitions,
                 security_definitions=security_definitions,
             )
     else:

--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -68,6 +68,7 @@ def generate_doc_from_each_end_point(
         api_version: str = "1.0.0",
         title: str = "Swagger API",
         contact: str = "",
+        definitions: dict = None,
         security_definitions: dict = None):
     # Clean description
     _start_desc = 0
@@ -98,6 +99,7 @@ def generate_doc_from_each_end_point(
                 title=title,
                 contact=contact,
                 base_path=api_base_url,
+                definitions=definitions,
                 security_definitions=security_definitions)
         )
 

--- a/aiohttp_swagger/templates/swagger.yaml
+++ b/aiohttp_swagger/templates/swagger.yaml
@@ -12,6 +12,10 @@ basePath: {{ base_path }}
 schemes:
   - http
   - https
+{% if definitions %}
+definitions:
+{{ definitions|nesteddict2yaml }}
+{% endif %}
 {% if security_definitions %}
 securityDefinitions:
 {{ security_definitions|nesteddict2yaml }}


### PR DESCRIPTION
This PR add possibility to provide data definitions to Swagger API.

I'm using schematics to describe models and I would like to publish their structure via Swagger specification.
For this I'm using a small library that I wrote and plan to publish it on PyPI  - https://github.com/Alexei-Kornienko/schematics_to_swagger
Usage might look the following way:
```
setup_swagger(
    app,
    title='API',
    api_version="3.0.0",
    definitions=schematics_to_swagger.read_models_from_module(models)
)
```