### PR TITLE
Fix class-based view

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -37,13 +37,15 @@ def _extract_swagger_docs(end_point_doc, method="get"):
         }
     return {method: end_point_swagger_doc}
 
+
 def _build_doc_from_func_doc(route):
 
     out = {}
-
-    if isclass(route.handler) and issubclass(route.handler, web.View) and route.method == METH_ANY:
+    is_method_allowed = route.method == METH_ANY or route.method in METH_ALL
+    
+    if isclass(route.handler) and issubclass(route.handler, web.View) and is_method_allowed:
         method_names = {
-            attr for attr in dir(route.handler) \
+            attr for attr in dir(route.handler)
             if attr.upper() in METH_ALL
         }
         for method_name in method_names:
@@ -59,6 +61,7 @@ def _build_doc_from_func_doc(route):
             return {}
         out.update(_extract_swagger_docs(end_point_doc))
     return out
+
 
 def generate_doc_from_each_end_point(
         app: web.Application,


### PR DESCRIPTION
When I add a class-based view to application route, I should to use a `router.add_route` method only and cat't use a `router.add_post`, `router.add_get` etc.
This is besause of statement in `builders._build_doc_from_func_doc` contains a `route.method == METH_ANY`