### PR TITLE
Fix file handle leak when building from file

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -155,7 +155,8 @@ def generate_doc_from_each_end_point(
 
 
 def load_doc_from_yaml_file(doc_path: str):
-    loaded_yaml = yaml.load(open(doc_path, "r", encoding="utf-8").read(), Loader=yaml.FullLoader)
+    with open(doc_path, "r", encoding="utf-8") as f:
+        loaded_yaml = yaml.load(f.read(), Loader=yaml.FullLoader)
     return json.dumps(loaded_yaml)
 
 


### PR DESCRIPTION
Properly close file handle after reading contents for yaml loader.