### PR TITLE
Removed tests from package distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     license='BSD',
     author='Daniel Garcia (cr0hn)',
     author_email='cr0hn@cr0hn.com',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     include_package_data=True,
     extras_require={
         'performance':  required_performance


### PR DESCRIPTION
Fixes a bug in setup.py where the distribution exports the package tests along with the actual library.

current SOURCES.txt from master branch:
```
CHANGELOG
LICENSE
...
aiohttp_swagger/templates/swagger.yaml
tests/__init__.py
tests/test_openapi.py
tests/test_swagger.py
```

This leads to a nasty name conflict in any project that depends on this library: if there is a top-level tests package, tests potentially break as from tests import helpers finds aiohttp-swagger's tests instead.