### PR TITLE
fix: Allow registering to the root (/) endpoint

### DIFF
--- a/aiohttp_swagger/__init__.py
+++ b/aiohttp_swagger/__init__.py
@@ -85,8 +85,9 @@ def setup_swagger(app: web.Application,
 
     # Add API routes
     app.router.add_route('GET', _swagger_url, _swagger_home_func)
-    app.router.add_route('GET', "{}/".format(_base_swagger_url),
-                         _swagger_home_func)
+    if _base_swagger_url:
+        app.router.add_route('GET', "{}/".format(_base_swagger_url),
+                             _swagger_home_func)
     app.router.add_route('GET', _swagger_def_url, _swagger_def_func)
 
     # Set statics


### PR DESCRIPTION
Hi, I just wanted the swagger UI to be the default page of my web app (which otherwise uses named endpoints), but hit an exception with the current code which tried to register the same endpoint twice in case of `swagger_url="/"`.

The fix is to not register the second endpoint that ends with a slash in case the `_base_swagger_url` is empty.