### PR TITLE
Include More Versions In The Dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyYAML>=5.1
-markupsafe~=1.1.1
-jinja2~=2.11.2
+jinja2>=2.11.2
 aiohttp>=2.3.10


### PR DESCRIPTION
* Other projects are limited to what can be set in their projects when including this with them (pyats)
* Removed explicit dependency on MarkupSafe
* Tests pass with the latest Jinja2 and it pulls in a newer MarkupSafe

Reference from the PyATS WebEx Teams room:
![image](https://user-images.githubusercontent.com/1091435/133693731-94c61fb5-3b98-4b2f-8278-2eb4663fcab0.png)
