### PR TITLE
Fix nesteddict2yaml not to fumble empty dict values

### DIFF
--- a/aiohttp_swagger/helpers/builders.py
+++ b/aiohttp_swagger/helpers/builders.py
@@ -94,7 +94,7 @@ def generate_doc_from_each_end_point(
     def nesteddict2yaml(d, indent=10, result=""):
         for key, value in d.items():
             result += " " * indent + str(key) + ':'
-            if isinstance(value, dict):
+            if isinstance(value, dict) and value:
                 result = nesteddict2yaml(value, indent + 2, result + "\n")
             elif isinstance(value, str):
                 result += " \"" + str(value) + "\"\n"

--- a/tests/data/example_data_definitions.json
+++ b/tests/data/example_data_definitions.json
@@ -37,6 +37,11 @@
         "type": "string",
         "description": "User's permission parameter",
         "default": "some_perm"
+      },
+      "permission_param_3": {
+        "type": "object",
+        "description": "User's permission parameter",
+        "default": {}
       }
     },
     "required": [

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -309,6 +309,7 @@ async def test_data_defs(aiohttp_client, loop):
     assert 'User' in result['components']['schemas']
     assert 'Permission' in result['components']['schemas']
     assert result['components']['schemas']['User']['properties']['permissions']['items']['$ref'] is not None
+    assert result['components']['schemas']['Permission']['properties']['permission_param_3']['default'] is not None
 
 
 async def test_sub_app(aiohttp_client, loop):

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -356,6 +356,7 @@ async def test_data_defs(aiohttp_client, loop):
     assert 'User' in result['definitions']
     assert 'Permission' in result['definitions']
     assert result['definitions']['User']['properties']['permissions']['items']['$ref'] is not None
+    assert result['definitions']['Permission']['properties']['permission_param_3']['default'] is not None
 
 
 async def test_sub_app(aiohttp_client, loop):


### PR DESCRIPTION
This PR fixes the internal `nesteddict2yaml()` function to process empty dict values properly.

Without this PR, empty dict values are rendered to `null` so that [openapi-spec-validator](https://github.com/python-openapi/openapi-spec-validator) fails on the Swagger Spec file generated from `app["SWAGGER_DEF_CONTENT"]`.

```python
from aiohttp import web
import aiohttp_swagger

app = web.Application()
definitions = dict(
    test={
        "type": "object",
        "properties": {"prop": {"type": "object", "default": dict()}},
    }
)
aiohttp_swagger.setup_swagger(app, ui_version=3, definitions=definitions)

with open("spec.json", "w") as fp:
    print(app["SWAGGER_DEF_CONTENT"], file=fp)
```

```json
{
  "openapi": "3.0.1",
  "info": {
    "title": "Swagger API",
    "description": "Swagger API definition",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "/"
    }
  ],
  "components": {
    "schemas": {
      "test": {
        "type": "object",
        "properties": {
          "prop": {
            "type": "object",
            "default": null
          }
        }
      }
    }
  },
  "paths": {}
}
```

```
spec.json: Validation Error: None for not nullable

Failed validating 'type' in schema:
    {'type': 'object', 'default': None}

On instance:
    None
```

Fixes: https://github.com/cr0hn/aiohttp-swagger/issues/106

P.S. Thank you for your great work on this project.